### PR TITLE
UA lang: improve translation for last_update

### DIFF
--- a/dict/ua.js
+++ b/dict/ua.js
@@ -17,7 +17,7 @@ module.exports = {
     delete: 'Видалити',
     write: 'Написати',
     hide: 'Приховати',
-    last_update: 'Свіже оновлення',
+    last_update: 'Оновлено',
 
     status_changed_my_mind: 'Перехотілося',
     status_make_changed_my_mind: 'Не хочу',


### PR DESCRIPTION
Обновил перевод для отметки о последнем обновлении списка желаний. 
В предыдущем MR (https://github.com/wantr/i18n/pull/5) перевел без учета контекста.
